### PR TITLE
Move some compiler options to a config file

### DIFF
--- a/picostdlib.nimble
+++ b/picostdlib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.10"
+version       = "0.2.11"
 author        = "Jason"
 description   = "Raspberry Pi Pico stdlib bindings/libraries"
 license       = "MIT"

--- a/src/piconim.nim
+++ b/src/piconim.nim
@@ -19,7 +19,7 @@ proc builder(program: string, output = "") =
 
   # compile the nim program to .c file
   let nimcmd = fmt"nim c -c --nimcache:{nimcache} --cpu:arm --os:any -d:useMalloc ./src/{program}"
-  echo nimcmd
+  echo fmt"Nim command line: {nimcmd}"
   let compileError = execCmd(nimcmd)
   if not compileError == 0:
     printError(fmt"unable to compile the provided nim program: {program}")

--- a/src/piconim.nim
+++ b/src/piconim.nim
@@ -18,7 +18,7 @@ proc builder(program: string, output = "") =
       removeFile(file)
 
   # compile the nim program to .c file
-  let compileError = execCmd(fmt"nim c -c --nimcache:{nimcache} --gc:arc --cpu:arm --os:any -d:release -d:useMalloc ./src/{program}")
+  let compileError = execCmd(fmt"nim c -c --nimcache:{nimcache} --cpu:arm --os:any -d:useMalloc ./src/{program}")
   if not compileError == 0:
     printError(fmt"unable to compile the provided nim program: {program}")
 

--- a/src/piconim.nim
+++ b/src/piconim.nim
@@ -18,7 +18,9 @@ proc builder(program: string, output = "") =
       removeFile(file)
 
   # compile the nim program to .c file
-  let compileError = execCmd(fmt"nim c -c --nimcache:{nimcache} --cpu:arm --os:any -d:useMalloc ./src/{program}")
+  let nimcmd = fmt"nim c -c --nimcache:{nimcache} --cpu:arm --os:any -d:useMalloc ./src/{program}"
+  echo nimcmd
+  let compileError = execCmd(nimcmd)
   if not compileError == 0:
     printError(fmt"unable to compile the provided nim program: {program}")
 

--- a/src/template/config.nims
+++ b/src/template/config.nims
@@ -1,0 +1,3 @@
+switch("define", "release")
+switch("mm", "arc") # use "arc", "orc" or "none"
+switch("define", "checkAbi")


### PR DESCRIPTION
Resolves #44 

Also:

* Echo the nim compiler command line for info/debugging reasons
* Add `-d:checkAbi` switch. I'm not super familiar with but it might help catch bad ffi object definitions in the future? It didn't flag anything in the codebase I'm working on.